### PR TITLE
bump-stack-version 8.0.0-9118114b

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.0.0-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.0.0-9118114b-SNAPSHOT
     ports:
       - 9200:9200
     healthcheck:
@@ -30,7 +30,7 @@ services:
       - "./testing/docker/elasticsearch/users_roles:/usr/share/elasticsearch/config/users_roles"
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.0.0-9118114b-SNAPSHOT
     ports:
       - 5601:5601
     healthcheck:


### PR DESCRIPTION
### What
  Bump stack version with the latest one.
  ### Further details
  ```
  [start_time:Thu, 22 Apr 2021 00:15:22 GMT, release_branch:master, prefix:, end_time:Thu, 22 Apr 2021 05:01:12 GMT, manifest_version:2.0.0, version:8.0.0-SNAPSHOT, branch:master, build_id:8.0.0-9118114b, build_duration_seconds:17150]
  ```